### PR TITLE
Remove option buttons on journal submit

### DIFF
--- a/src/features/journal.ts
+++ b/src/features/journal.ts
@@ -3,7 +3,7 @@ import { App, ButtonAction } from "@slack/bolt";
 import { postToJournal } from "../util/entries/index";
 import { getEntryById } from "../util/db/index";
 import { Entry } from "../types/index";
-import { postMessageCurry } from "../util/index";
+import { postMessageCurry, updateBlockMessage } from "../util/index";
 const journal = async (app: App) => {
   app.action("postEntry", async ({ ack, context, body, action }) => {
     await ack();
@@ -29,6 +29,20 @@ const journal = async (app: App) => {
       im(null, "You've already submitted that message, sorry.");
     } else {
       await postToJournal(`<@${user}>`, entry, id, user);
+      await updateBlockMessage(
+        body.channel.id,
+        body.message.ts,
+        [
+          body.message.blocks[0],
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "✅"
+            }
+          },
+        ]
+      )
       await im([
         {
           type: "section",

--- a/src/features/journal.ts
+++ b/src/features/journal.ts
@@ -25,34 +25,30 @@ const journal = async (app: App) => {
     console.log(submitted);
     // console.log(entry)
 
-    if (submitted) {
-      im(null, "You've already submitted that message, sorry.");
-    } else {
-      await postToJournal(`<@${user}>`, entry, id, user);
-      await updateBlockMessage(
-        body.channel.id,
-        body.message.ts,
-        [
-          body.message.blocks[0],
-          {
-            "type": "section",
-            "text": {
-              "type": "mrkdwn",
-              "text": "✅"
-            }
-          },
-        ]
-      )
-      await im([
+    await postToJournal(`<@${user}>`, entry, id, user);
+    await updateBlockMessage(
+      body.channel.id,
+      body.message.ts,
+      [
+        body.message.blocks[0],
         {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: `I've sent your message to <#${journal_channel}>.\n\nThanks for creating an entry (id: ${id}) today! Feel free to come back anytime, <@${user}> :D`,
-          },
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "✅"
+          }
         },
-      ]);
-    }
+      ]
+    )
+    await im([
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `I've sent your message to <#${journal_channel}>.\n\nThanks for creating an entry (id: ${id}) today! Feel free to come back anytime, <@${user}> :D`,
+        },
+      },
+    ]);
   });
 
   app.action("postEntryAnonymously", async ({ ack, context, body, action }) => {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -11,6 +11,15 @@ export const postMessage = (channel: string, blocks?: (any)[], text: string = ""
     })
 }
 
+export const updateBlockMessage = (channel: string, ts: string, blocks?: (any)[]) => {
+    return app.client.chat.update({
+        token,
+        ts,
+        channel,
+        blocks
+    })
+}
+
 export const postMessageCurry = (channel: string) => (blocks?: (any)[], text: string = "") => {
     return app.client.chat.postMessage({
         channel: channel,


### PR DESCRIPTION
![](https://cloud-lk4wvz0rl.vercel.app/screen_shot_2020-09-17_at_5.31.39_pm.png)

Small edit based on my personal opinion, feel free to close if this isn't your vibe. Right now when you click on the buttons to submit a journal entry, it keeps the buttons around after you submit but it doesn't let you submit again. This PR removes the buttons once you click one of them and replaces them with a ✅ 

(Code is untested. I've never used TypeScript before, and the Codespace gave me some weird errors, but I think I did everything right 🤔)